### PR TITLE
Add static open() methods

### DIFF
--- a/src/main/java/spullara/nio/channels/FutureServerSocketChannel.java
+++ b/src/main/java/spullara/nio/channels/FutureServerSocketChannel.java
@@ -3,6 +3,7 @@ package spullara.nio.channels;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
+import java.nio.channels.AsynchronousChannelGroup;
 import java.nio.channels.AsynchronousServerSocketChannel;
 import java.nio.channels.AsynchronousSocketChannel;
 import java.nio.channels.CompletionHandler;
@@ -40,5 +41,13 @@ public class FutureServerSocketChannel {
 
     public InetSocketAddress getLocalAddress() throws IOException {
         return (InetSocketAddress) assc.getLocalAddress();
+    }
+
+    public static FutureServerSocketChannel open() throws IOException {
+        return new FutureServerSocketChannel(AsynchronousServerSocketChannel.open());
+    }
+
+    public static FutureServerSocketChannel open(AsynchronousChannelGroup group) throws IOException {
+        return new FutureServerSocketChannel(AsynchronousServerSocketChannel.open(group));
     }
 }

--- a/src/main/java/spullara/nio/channels/FutureSocketChannel.java
+++ b/src/main/java/spullara/nio/channels/FutureSocketChannel.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.nio.ByteBuffer;
+import java.nio.channels.AsynchronousChannelGroup;
 import java.nio.channels.AsynchronousSocketChannel;
 import java.nio.channels.CompletionHandler;
 import java.util.concurrent.CompletableFuture;
@@ -72,5 +73,13 @@ public class FutureSocketChannel {
 
     public int getPort() throws IOException {
         return ((InetSocketAddress)asc.getLocalAddress()).getPort();
+    }
+
+    public static FutureSocketChannel open() throws IOException {
+        return new FutureSocketChannel(AsynchronousSocketChannel.open());
+    }
+
+    public static FutureSocketChannel open(AsynchronousChannelGroup group) throws IOException {
+        return new FutureSocketChannel(AsynchronousSocketChannel.open(group));
     }
 }


### PR DESCRIPTION
This allows using a user supplied AsynchronousChannelGroup with the same
API as the baseline AsynchronousSocketChannel.